### PR TITLE
ansible_check_modeの場合には処理をスキップするよう修正

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -34,10 +34,12 @@
     install_recommends: no
     update_cache: "{{ 'yes' if not ansible_check_mode | bool else 'no' }}"
   when:
-    not ansible_check_mode or
-    nvidia_driver_repo == "ubuntu" or
-    not nvidia_driver_ppa_apt_repo.changed|default(true) or
-    not nvidia_repo_cuda_apt_repo.changed|default(true)
+    not ansible_check_mode and 
+    (
+      nvidia_driver_repo == "ubuntu" or
+      not nvidia_driver_ppa_apt_repo.changed|default(true) or
+      not nvidia_repo_cuda_apt_repo.changed|default(true)
+    )
 
   vars:
     nvidia_driver_packages:


### PR DESCRIPTION
`NVIDIA graphics driver {{ nvidia_driver_package_name }} is installed`の処理は全段までで設定ファイルの変更がデプロイされていることに依存している。
`ansible_check_mode == true` の時は設定ファイル内容が補償されないので、`NVIDIA graphics driver {{ nvidia_driver_package_name }} is installed`の処理は`ansible_check_mode == true`の時にスキップされるべきである
本PRでは`NVIDIA graphics driver {{ nvidia_driver_package_name }} is installed`の処理は`ansible_check_mode == true`の時にスキップされるように修正した
`not ansible_check_mode or`という条件分がもともと存在するが、おそらく本PRで意図した挙動のための実装（しかし誤っている）であると思われる